### PR TITLE
Fix checksum in the new update of Shottr 1.8.0

### DIFF
--- a/Casks/s/shottr.rb
+++ b/Casks/s/shottr.rb
@@ -1,6 +1,6 @@
 cask "shottr" do
   version "1.8.0"
-  sha256 "811788bc0c8244af54c5f5e13f60e4e16f16523eaad5d6443fb4b00e576de632"
+  sha256 "892458d3b3cf16130a1b55fff2e9e37960e9f139ae5dc10fd479a64fed929c42"
 
   url "https://shottr.cc/dl/Shottr-#{version}.dmg"
   name "Shottr"


### PR DESCRIPTION
Another patch following #186979, as the sum appears to be different again.

**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [ ] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [ ] `brew audit --cask --online <cask>` is error-free.
- [ ] `brew style --fix <cask>` reports no offenses.

Additionally, **if adding a new cask**:

- [ ] Named the cask according to the [token reference](https://docs.brew.sh/Cask-Cookbook#token-reference).
- [ ] Checked the cask was not [already refused](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-cask+is%3Aclosed+is%3Aunmerged+&type=pullrequests) (add your cask's name to the end of the search field).
- [ ] `brew audit --cask --new <cask>` worked successfully.
- [ ] `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --cask <cask>` worked successfully.
- [ ] `brew uninstall --cask <cask>` worked successfully.

---

Another patch following #186979, as the sum appears to be different again.

<img width="562" alt="image" src="https://github.com/user-attachments/assets/6cf72870-938c-4fc9-8e26-80b7e2d5e94a">